### PR TITLE
Add support for SwiftPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,7 +5,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/logansease/QwikJson",
       "state" : {
-        "revision" : "47b46dc4ebf2f8b7e0d4b00c4ef6918ce5f1fa8d",
+        "revision" : "a45dd68a8c0e1ac217bdf556455439cc689829e4",
         "version" : "1.1.0"
       }
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "qwikjson",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jurvis/QwikJson",
+      "location" : "https://github.com/lsease/QwikJson",
       "state" : {
         "revision" : "47b46dc4ebf2f8b7e0d4b00c4ef6918ce5f1fa8d",
         "version" : "1.1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "qwikjson",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lsease/QwikJson",
+      "location" : "https://github.com/logansease/QwikJson",
       "state" : {
         "revision" : "47b46dc4ebf2f8b7e0d4b00c4ef6918ce5f1fa8d",
         "version" : "1.1.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "qwikjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jurvis/QwikJson",
+      "state" : {
+        "revision" : "47b46dc4ebf2f8b7e0d4b00c4ef6918ce5f1fa8d",
+        "version" : "1.1.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["QwikHttp"])
     ],
     dependencies: [
-        .package(url: "https://github.com/jurvis/QwikJson", from: "1.1.0"),
+        .package(url: "https://github.com/logansease/QwikJson", from: "1.1.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "QwikHttp",
+    platforms: [
+        .macOS(.v10_14), .iOS(.v13), .tvOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "QwikHttp",
+            targets: ["QwikHttp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/jurvis/QwikJson", from: "1.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "QwikHttp",
+            dependencies: [.product(name: "QwikJson", package: "QwikJson")],
+            path: "QwikHttp/Classes"
+        )
+    ]
+)


### PR DESCRIPTION
Depends on https://github.com/logansease/QwikJson/pull/1

## Pre-Merge To-Do
- [x] Tag `QwikJson` with `1.1.0` release post-merging ttps://github.com/logansease/QwikJson/pull/1
- [x] Update QwikHttp `Package.swift` to use `https://github.com/logansease/QwikJson`instead
- [x] Update revision hash in `Package.resolved`

## Post Merge To-Do
- [x] Create a tag post-merge marking `1.13.0`